### PR TITLE
Version 1.3.2

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.24" />
+    <option name="version" value="2.0.0" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,9 @@
 import java.util.Properties
 
 plugins {
-    alias(libs.plugins.androidApplication)
-    alias(libs.plugins.kotlinAndroid)
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
 }
 
 val keystorePropertiesFile = rootProject.file("key.properties")
@@ -17,7 +18,7 @@ kotlin {
 
 android {
     namespace = "com.mateusrodcosta.apps.share2storage"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.mateusrodcosta.apps.share2storage"
@@ -72,9 +73,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.androidxComposeCompiler.get()
-    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -83,9 +81,9 @@ android {
 }
 
 dependencies {
-    implementation(libs.kotlinx.coroutines)
+    implementation(libs.coroutines)
     implementation(libs.bundles.androidx.ktx)
-    implementation(libs.androidx.core.splashscreen)
+    implementation(libs.splashscreen)
 
     val composeBom = platform(libs.compose.bom)
     implementation(composeBom)
@@ -93,7 +91,7 @@ dependencies {
 
     implementation(libs.bundles.compose)
     debugImplementation(libs.bundles.compose.debug)
-    implementation(libs.bundles.androidx.compose.integration)
+    implementation(libs.bundles.compose.integration)
 
     testImplementation(libs.bundles.testing)
     androidTestImplementation(libs.bundles.ui.testing)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,9 +23,10 @@ android {
     defaultConfig {
         applicationId = "com.mateusrodcosta.apps.share2storage"
         minSdk = 26
+        //noinspection OldTargetApi
         targetSdk = 34
-        versionCode = 22
-        versionName = "1.3.1"
+        versionCode = 23
+        versionName = "1.3.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.App" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="Theme.App" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">false</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.App" parent="@android:style/Theme.Material.Light.NoActionBar">
+    <style name="Theme.App" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">false</item>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
-    alias(libs.plugins.androidApplication) apply false
-    alias(libs.plugins.kotlinAndroid) apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }

--- a/fastlane/metadata/android/en-US/changelogs/23.txt
+++ b/fastlane/metadata/android/en-US/changelogs/23.txt
@@ -1,0 +1,5 @@
+<strong>IMPORTANT</strong>:
+Starting in v1.2.3, a 1 kb buffer is used for the file copy, but that introduced a bug: zeroes might be added at the end of the saved file.
+This was fixed in 1.3.1, please report any issue you may find!
+
+Version 1.3.2 is a maintenance release which updates dependencies and brings minor under-the-hood changes.

--- a/fastlane/metadata/android/pt-BR/changelogs/23.txt
+++ b/fastlane/metadata/android/pt-BR/changelogs/23.txt
@@ -1,0 +1,5 @@
+<strong>IMPORTANTE</strong>:
+A partir da versão 1.2.3 a cópia de arquivo passou a usar um buffer de 1 kb, mas isso introduziu um bug: zeros poderiam ser adicionados no final do arquivo salvo.
+Isso foi corrigido na versão 1.3.1, por favor reporte qualquer problema!
+
+A versão 1.3.2 é um lançamento de manutenção que atualiza dependências e traz algumas mudanças pequenas por baixo dos panos.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,25 +1,24 @@
 [versions]
-agp = "8.5.2"
-kotlin = "1.9.24"
-androidxComposeCompiler = "1.5.14"
+agp = "8.6.0"
+kotlin = "2.0.0"
 ktx = "1.13.1"
 preference-ktx = "1.2.1"
-lifecycle-runtime-ktx = "2.8.4"
+lifecycle-runtime-ktx = "2.8.5"
 splashscreen = "1.0.1"
-composeBom = "2024.08.00"
-activityCompose = "1.9.1"
-navigationCompose = "2.7.7"
+composeBom = "2024.09.01"
+activityCompose = "1.9.2"
+navigationCompose = "2.8.0"
 junit = "4.13.2"
 androidxTestRunner = "1.6.2"
 androidxTestRules = "1.6.1"
 coroutines = "1.7.3"
 
 [libraries]
-kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
-androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference-ktx" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle-runtime-ktx" }
-androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
+coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
+preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference-ktx" }
+lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle-runtime-ktx" }
+splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 compose-material3-window-size-classes = { group = "androidx.compose.material3", name = "material3-window-size-class" }
@@ -28,20 +27,21 @@ compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
-androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-test-runner = { group = "androidx.test", name="runner", version.ref = "androidxTestRunner" }
-androidx-test-rules = { group = "androidx.test", name="rules", version.ref = "androidxTestRules" }
+test-runner = { group = "androidx.test", name="runner", version.ref = "androidxTestRunner" }
+test-rules = { group = "androidx.test", name="rules", version.ref = "androidxTestRules" }
 
 [bundles]
-androidx-ktx = ["androidx.core.ktx", "androidx.preference.ktx", "androidx.lifecycle.runtime.ktx"]
+androidx-ktx = ["core.ktx", "preference.ktx", "lifecycle.runtime.ktx"]
 compose = ["compose.material3", "compose.material3.window.size.classes", "compose.ui.tooling.preview", "compose.ui.material.icons.extended"]
 compose-debug = ["compose.ui.tooling", "compose.ui.test.manifest"]
-androidx-compose-integration = ["androidx.activity.compose", "androidx.navigation.compose"]
+compose-integration = ["activity.compose", "navigation.compose"]
 testing = ["junit"]
-ui-testing = ["androidx.test.runner", "androidx.test.rules", "compose.ui.test.junit4"]
+ui-testing = ["test.runner", "test.rules", "compose.ui.test.junit4"]
 
 [plugins]
-androidApplication = { id = "com.android.application", version.ref = "agp" }
-kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=5b9c5eb3f9fc2c94abaea57d90bd78747ca117ddbbf96c859d3741181a12bf2a
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionSha256Sum=1541fa36599e12857140465f3c91a97409b4512501c26f9631fb113e392c5bd1
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Changelog

**IMPORTANT**:
Starting in v1.2.3, a 1 kb buffer is used for the file copy, but that introduced a bug: zeroes might be added at the end of the saved file.
This was fixed in 1.3.1, please report any issue you may find!

Version 1.3.2 is a maintenance release which updates dependencies and brings minor under-the-hood changes.