### PR TITLE
Skip release configs when there is no keystore file

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,8 @@ val keystorePropertiesFile = rootProject.file("key.properties")
 val keystoreProperties = Properties()
 if (keystorePropertiesFile.exists()) {
     keystoreProperties.load(keystorePropertiesFile.inputStream())
+} else {
+    project.logger.warn("Could not find the release keystore, hiding release variant.")
 }
 
 kotlin {
@@ -31,26 +33,30 @@ android {
     }
 
     signingConfigs {
-        create("release") {
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
-            storeFile = file(keystoreProperties["storeFile"] as String)
-            storePassword = keystoreProperties["storePassword"] as String
+        if (keystoreProperties.isNotEmpty()) {
+            create("release") {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
 
-            // Disable v2 signing and force enable v3 signing, which will be used on modern Android (9+)
-            enableV2Signing = false
-            enableV3Signing = true
+                // Disable v2 signing and force enable v3 signing, which will be used on modern Android (9+)
+                enableV2Signing = false
+                enableV3Signing = true
+            }
         }
     }
 
     buildTypes {
-        getByName("release") {
-            isMinifyEnabled = true
-            isShrinkResources = true
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
-            )
-            signingConfig = signingConfigs.getByName("release")
+        if (keystoreProperties.isNotEmpty()) {
+            getByName("release") {
+                isMinifyEnabled = true
+                isShrinkResources = true
+                proguardFiles(
+                    getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
+                )
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
         getByName("debug") {
             applicationIdSuffix = ".debug"


### PR DESCRIPTION
Pretty basic, it was just a minor annoyance that I couldn't sync the project after cloning :)